### PR TITLE
fix zeroconf config

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,7 +8,7 @@
     "dependencies": [],
     "config_flow": true,
     "zeroconf": [
-        { "type":"_http._tcp.local.", "name":"Pentair*"}
+        { "type":"_http._tcp.local.", "name":"pentair*" }
       ],
     "quality_scale": "gold"
   }


### PR DESCRIPTION
On my system, the panel is broadcasting zeroconf under `_ssh._tcp` instead of `_http._tcp`. Changing this made automatic discovery of the integration work for me.
It seems a bit odd that it advertises port 22 but it does work.

![image](https://user-images.githubusercontent.com/118850/114122642-b43c7000-98be-11eb-8294-70ea624b8255.png)
