### PR TITLE
set device class and state class properly

### DIFF
--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -6,9 +6,12 @@ from typing import Optional
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_TEMPERATURE,
     POWER_WATT,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -57,7 +60,7 @@ async def async_setup_entry(
                     entry,
                     controller,
                     object,
-                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    device_class=SensorDeviceClass.TEMPERATURE,
                     attribute_key=SOURCE_ATTR,
                 )
             )
@@ -68,7 +71,7 @@ async def async_setup_entry(
                         entry,
                         controller,
                         object,
-                        device_class=DEVICE_CLASS_ENERGY,
+                        device_class=SensorDeviceClass.POWER,
                         unit_of_measurement=POWER_WATT,
                         attribute_key=PWR_ATTR,
                         name="+ power",
@@ -105,7 +108,7 @@ async def async_setup_entry(
                     entry,
                     controller,
                     object,
-                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    device_class=SensorDeviceClass.TEMPERATURE,
                     attribute_key=LSTTMP_ATTR,
                     name="+ last temp",
                 )
@@ -115,7 +118,7 @@ async def async_setup_entry(
                     entry,
                     controller,
                     object,
-                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    device_class=SensorDeviceClass.TEMPERATURE,
                     attribute_key=LOTMP_ATTR,
                     name="+ desired temp",
                 )
@@ -196,7 +199,7 @@ async def async_setup_entry(
 # -------------------------------------------------------------------------------------
 
 
-class PoolSensor(PoolEntity):
+class PoolSensor(PoolEntity, SensorEntity):
     """Representation of an Pentair sensor."""
 
     def __init__(
@@ -204,19 +207,15 @@ class PoolSensor(PoolEntity):
         entry: ConfigEntry,
         controller: ModelController,
         poolObject: PoolObject,
-        device_class: str,
+        device_class: Optional[SensorDeviceClass],
         rounding_factor: int = 0,
         **kwargs,
     ):
         """Initialize."""
         super().__init__(entry, controller, poolObject, **kwargs)
-        self._device_class = device_class
+        self._attr_device_class = device_class
         self._rounding_factor = rounding_factor
-
-    @property
-    def device_class(self) -> Optional[str]:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        self._device_class
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def state(self) -> str:
@@ -236,6 +235,6 @@ class PoolSensor(PoolEntity):
     @property
     def unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement of this entity, if any."""
-        if self._device_class == DEVICE_CLASS_TEMPERATURE:
+        if self._attr_device_class == SensorDeviceClass.TEMPERATURE:
             return self.pentairTemperatureSettings()
         return self._unit_of_measurement


### PR DESCRIPTION
I was struggling to get energy monitoring working with my pump power and eventually discovered that the Pump Power sensor was using the wrong device class (was using `ENERGY` and should be `POWER`), and we were not even setting the device class properly (`_device_class` vs `_attr_device_class`). I also started using the `SensorDeviceClass` enum since that's the recommended way to do it now.

I've tested this locally and it works, and I can get the energy integration working now too.