### PR TITLE
refactor to use modern attr patterns

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -223,13 +223,14 @@ class PoolEntity(Entity):
         self._entry_id = entry.entry_id
         self._controller = controller
         self._poolObject = poolObject
-        self._available = True
+        self._attr_available = True
         self._extra_state_attributes = extraStateAttributes
-        self._name = name
+        self._attr_name = name
         self._attribute_key = attribute_key
-        self._enabled_by_default = enabled_by_default
-        self._unit_of_measurement = unit_of_measurement
-        self._icon = icon
+        self._attr_entity_registry_enabled_default = enabled_by_default
+        self._attr_native_unit_of_measurement = unit_of_measurement
+        self._attr_icon = icon
+        self._attr_should_poll = False
 
         _LOGGER.debug(f"mapping {poolObject}")
 
@@ -254,37 +255,17 @@ class PoolEntity(Entity):
         _LOGGER.debug(f"removing entity: {self.unique_id}")
 
     @property
-    def entity_registry_enabled_default(self):
-        """Return True if the entity is enabled by default."""
-        return self._enabled_by_default
-
-    @property
-    def available(self):
-        """Return True is the entity is available."""
-        return self._available
-
-    @property
     def name(self):
         """Return the name of the entity."""
 
-        if self._name is None:
+        if self._attr_name is None:
             # default is to return the name of the underlying pool object
             return self._poolObject.sname
-        elif self._name.startswith("+"):
+        elif self._attr_name.startswith("+"):
             # name is a suffix
-            return self._poolObject.sname + self._name[1:]
+            return self._poolObject.sname + self._attr_name[1:]
         else:
-            return self._name
-
-    @property
-    def icon(self) -> Optional[str]:
-        """Return the icon for the entity, if any."""
-        return self._icon
-
-    @property
-    def unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement of this entity, if any."""
-        return self._unit_of_measurement
+            return self._attr_name
 
     @property
     def unique_id(self):
@@ -293,11 +274,6 @@ class PoolEntity(Entity):
         if self._attribute_key != STATUS_ATTR:
             my_id += self._attribute_key
         return my_id
-
-    @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
 
     @property
     def device_info(self):
@@ -353,7 +329,7 @@ class PoolEntity(Entity):
         """Update the entity if its underlying pool object has changed."""
 
         if self.isUpdated(updates):
-            self._available = True
+            self._attr_available = True
             _LOGGER.debug(f"updating {self} from {updates}")
             self.async_write_ha_state()
 
@@ -366,7 +342,7 @@ class PoolEntity(Entity):
                 # this is for the rare case where the object the entity is mapped to
                 # had been removed from the Pentair system while we were disconnected
                 return
-        self._available = is_connected
+        self._attr_available = is_connected
         self.async_write_ha_state()
 
     def pentairTemperatureSettings(self):

--- a/custom_components/intellicenter/binary_sensor.py
+++ b/custom_components/intellicenter/binary_sensor.py
@@ -33,7 +33,14 @@ async def async_setup_entry(
     object: PoolObject
     for object in controller.model.objectList:
         if object.objtype == CIRCUIT_TYPE and object.subtype == "FRZ":
-            sensors.append(PoolBinarySensor(entry, controller, object))
+            sensors.append(
+                PoolBinarySensor(
+                    entry,
+                    controller,
+                    object,
+                    icon = "mdi:snowflake"
+                )
+            )
         elif object.objtype == HEATER_TYPE:
             sensors.append(
                 HeaterBinarySensor(
@@ -99,6 +106,7 @@ class HeaterBinarySensor(PoolEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(entry, controller, poolObject, **kwargs)
         self._bodies = set(poolObject[BODY_ATTR].split(" "))
+        self._attr_icon = "mdi:fire-circle"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -1,7 +1,6 @@
 """Pentair Intellicenter numbers."""
 
 import logging
-from typing import Optional
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -51,7 +50,6 @@ async def async_setup_entry(
                     unit_of_measurement=PERCENTAGE,
                     attribute_key=PRIM_ATTR,
                     name="+ Output %",
-                    icon="mdi:gauge",
                 )
             )
     async_add_entities(numbers)
@@ -61,7 +59,7 @@ async def async_setup_entry(
 
 
 class PoolNumber(PoolEntity, NumberEntity):
-    """Representation of a number."""
+    """Representation of a pool number entity."""
 
     def __init__(
         self,
@@ -75,31 +73,17 @@ class PoolNumber(PoolEntity, NumberEntity):
     ):
         """Initialize."""
         super().__init__(entry, controller, poolObject, **kwargs)
-        self._min_value = min_value
-        self._max_value = max_value
-        self._step = step
+        self._attr_native_min_value = min_value
+        self._attr_native_max_value = max_value
+        self._attr_native_step = step
+        self._attr_icon = "mdi:gauge"
 
     @property
-    def min_value(self) -> float:
-        """Return the minimum value."""
-        return self._min_value
-
-    @property
-    def max_value(self) -> float:
-        """Return the maximum value."""
-        return self._max_value
-
-    @property
-    def step(self) -> float:
-        """Return the increment/decrement step."""
-        return self._step
-
-    @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return the current value."""
         return self._poolObject[self._attribute_key]
 
-    def set_value(self, value: float) -> None:
+    def set_native_value(self, value: float) -> None:
         """Update the current value."""
         changes = {self._attribute_key: str(int(value))}
         self.requestChanges(changes)

--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -233,8 +233,8 @@ class PoolSensor(PoolEntity, SensorEntity):
         return value
 
     @property
-    def unit_of_measurement(self) -> Optional[str]:
+    def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement of this entity, if any."""
         if self._attr_device_class == SensorDeviceClass.TEMPERATURE:
             return self.pentairTemperatureSettings()
-        return self._unit_of_measurement
+        return self._attr_native_unit_of_measurement

--- a/custom_components/intellicenter/switch.py
+++ b/custom_components/intellicenter/switch.py
@@ -25,8 +25,6 @@ from .pyintellicenter import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# FIXME: for freeze swtch use icon mdi:snowflake
-
 # -------------------------------------------------------------------------------------
 
 
@@ -62,7 +60,8 @@ async def async_setup_entry(
             and not (object.isALight or object.isALightShow)
             and object.isFeatured
         ):
-            switches.append(PoolCircuit(entry, controller, object))
+            switches.append(
+                PoolCircuit(entry, controller, object, icon="mdi:alpha-f-box-outline"))
         elif object.objtype == SYSTEM_TYPE:
             switches.append(
                 PoolCircuit(
@@ -71,6 +70,7 @@ async def async_setup_entry(
                     object,
                     VACFLO_ATTR,
                     name="Vacation mode",
+                    icon="mdi:palm-tree",
                     enabled_by_default=False,
                 )
             )
@@ -108,8 +108,4 @@ class PoolBody(PoolCircuit):
         """Initialize a Pool body from the underlying circuit."""
         super().__init__(entry, controller, poolObject)
         self._extra_state_attributes = [VOL_ATTR, HEATER_ATTR, HTMODE_ATTR]
-
-    @property
-    def icon(self):
-        """Return the icon for the entity."""
-        return "mdi:pool"
+        self._attr_icon = "mdi:pool"

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -92,6 +92,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         )
         self._heater_list = heater_list
         self._lastHeater = self._poolObject[HEATER_ATTR]
+        self._attr_icon = "mdi:thermometer"
 
     @property
     def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
@@ -123,11 +124,6 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
     def supported_features(self):
         """Return the list of supported features."""
         return SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
-
-    @property
-    def icon(self):
-        """Return the entity icon."""
-        return "mdi:thermometer"
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
The current recommended way to set entity properties is with attributes named via convention: https://developers.home-assistant.io/docs/core/entity#entity-class-or-instance-attributes

This removes a lot of boilerplate code which keeps things simpler.