### PR TITLE
Revert "Addressing warning in HA 2024.2 RE: the need to set supported…

### DIFF
--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -4,12 +4,7 @@ from functools import reduce
 import logging
 from typing import Any, Dict
 
-from homeassistant.components.light import (
-    ATTR_EFFECT,
-    ColorMode,
-    LightEntity,
-    LightEntityFeature,
-)
+from homeassistant.components.light import ATTR_EFFECT, LightEntity, LightEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -62,6 +57,7 @@ async def async_setup_entry(
                 )
             )
         elif object.isALightShow:
+
             supportColorEffects = reduce(
                 lambda x, y: x and y,
                 map(
@@ -98,7 +94,6 @@ class PoolLight(PoolEntity, LightEntity):
         self._extra_state_attributes = [USE_ATTR]
 
         self._features = 0
-        self._supported_color_modes = ColorMode.ONOFF
 
         self._lightEffects = colorEffects
         self._reversedLightEffects = (
@@ -112,11 +107,6 @@ class PoolLight(PoolEntity, LightEntity):
     def supported_features(self) -> int:
         """Return supported features."""
         return self._features
-
-    @property
-    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
-        """Return supported color modes."""
-        return self._supported_color_modes
 
     @property
     def effect_list(self) -> list:


### PR DESCRIPTION
… color modes explicitly"

This reverts commit cf4eaeec82a47177fc9b9c6e80b925e78c034cfd.

I identified this as the root cause of why I could no longer control lights. 
So this addressed https://github.com/jlvaillant/intellicenter/issues/75 .